### PR TITLE
fix null exception when loading settings

### DIFF
--- a/Configurations/Avatar Config Low.asset
+++ b/Configurations/Avatar Config Low.asset
@@ -18,4 +18,5 @@ MonoBehaviour:
   TextureSizeLimit: 256
   UseHands: 0
   UseDracoCompression: 0
-  MorphTargets: []
+  MorphTargets:
+  - none

--- a/Configurations/Avatar Config Medium.asset
+++ b/Configurations/Avatar Config Medium.asset
@@ -18,4 +18,5 @@ MonoBehaviour:
   TextureSizeLimit: 512
   UseHands: 0
   UseDracoCompression: 0
-  MorphTargets: []
+  MorphTargets:
+  - Oculus Visemes

--- a/Runtime/Data/ReadyPlayerMeSettings.cs
+++ b/Runtime/Data/ReadyPlayerMeSettings.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using UnityEditor;
+using UnityEngine;
 
 namespace ReadyPlayerMe.Core
 {
@@ -16,7 +17,12 @@ namespace ReadyPlayerMe.Core
             {
                 if (instance == null)
                 {
+#if DISABLE_AUTO_INSTALLER && UNITY_EDITOR
+                    instance = AssetDatabase.LoadAssetAtPath<ReadyPlayerMeSettings>(
+                        $"Assets/Ready Player Me/Core/{SETTINGS_RESOURCE_PATH}.asset");
+#else
                     instance = Resources.Load<ReadyPlayerMeSettings>(SETTINGS_RESOURCE_PATH);
+#endif
                 }
 
                 return instance;


### PR DESCRIPTION
## Description

Fixed null exception when loading instance of settings through settings asset.

## How to Test

Verify if there is no null exception while opening settings window